### PR TITLE
bypass AssertionError: Min Version must be int

### DIFF
--- a/anti_useragent/useragent/__init__.py
+++ b/anti_useragent/useragent/__init__.py
@@ -24,9 +24,12 @@ class BaseUserAgent:
         self.min_version = min_version
         self.max_version = max_version
 
-        assert isinstance(self.min_version, int), 'Min Version must be int'
-        assert isinstance(self.max_version, int), 'Max Version must be int'
-        assert isinstance(platform or "", str), 'Platform must be string or NoneType'
+        if min_version:
+            assert isinstance(self.min_version, int), 'Min Version must be int'
+        if max_version:
+            assert isinstance(self.max_version, int), 'Max Version must be int'
+        if platform:
+            assert isinstance(platform or "", str), 'Platform must be string or NoneType'
 
         if all([platform, (platform not in self.settings.get('PLATFORM'))]):
             raise TypeError('Unknown platform type: %s' % platform)


### PR DESCRIPTION
Initialization without specifying the minimum and maximum versions 
```python3
ua = UserAgent()
```
causes an error
```python3
  File "/home/user/.local/lib/python3.10/site-packages/anti_useragent/useragent/ua.py", line 66, in __getattr__
    _ua = self._shortcut[_attr](
  File "/home/user/.local/lib/python3.10/site-packages/anti_useragent/useragent/browser/wechat.py", line 37, in __init__
    super().__init__(*args, **kwargs)
  File "/home/user/.local/lib/python3.10/site-packages/anti_useragent/useragent/__init__.py", line 27, in __init__
    assert isinstance(self.min_version, int), 'Min Version must be int'
AssertionError: Min Version must be int
```